### PR TITLE
Change prom-client to peer-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-wrapper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Makes prometheus easier to use in a nodejs app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,13 +23,15 @@
   },
   "homepage": "https://github.com/iadvize/prometheus-wrapper",
   "dependencies": {
-    "lodash": "^4.11.1",
-    "prom-client": "^3.4.1"
+    "lodash": "^4.11.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "express": "^4.13.4",
     "mocha": "^2.4.5",
     "supertest": "^1.2.0"
+  },
+  "peerDependencies": {
+    "prom-client": "^7.2.0"
   }
 }


### PR DESCRIPTION
This change is necessary to be able to use epimetheus in parallel of this module.